### PR TITLE
Update address.rb

### DIFF
--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,5 +1,5 @@
 class Address < ApplicationRecord
-  extend ActiveHash::Associations::ActiveRecordExtensions
+  # extend ActiveHash::Associations::ActiveRecordExtensions
 
   validates :postal_code, :prefecture, :city, :address_number ,presence: true
   validates :sendfirst_name, :sendlast_name ,presence: true,


### PR DESCRIPTION
#what
新規登録の機能でエラーが出たので、原因となっている下記の1行を消したものです。
extend ActiveHash::Associations::ActiveRecordExtensions

activehashを使わない仕様に途中からシフトしたので、activehash関連の記述を全て消したつもりが、これだけ残ってしまいActiveHashのnameerrorが出ていた次第です。

正常に動くことを確認したので、マージお願いします。